### PR TITLE
add simple install script

### DIFF
--- a/install
+++ b/install
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+PREFIX=${1:-/usr/local}
+
+mkdir -p "$PREFIX/lib/git-fuzzy"
+/bin/cp -f -t "$PREFIX/lib/git-fuzzy" -r lib/*
+
+mkdir -p "$PREFIX/bin"
+# change lib_dir="..." to $PREFIX/lib/git-fuzzy
+sed -- 's!^\(lib_dir=\).*$!\1"'$PREFIX'/lib/git-fuzzy"!' \
+  bin/git-fuzzy >"$PREFIX/bin/git-fuzzy"
+chmod +x "$PREFIX/bin/git-fuzzy"

--- a/uninstall
+++ b/uninstall
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+PREFIX=${1:-/usr/local}
+
+rm -rf "$PREFIX/lib/git-fuzzy"
+rm -f "$PREFIX/bin/git-fuzzy"


### PR DESCRIPTION
This is a neat project :exploding_head:. I think it could benefit from a simple install script too.

```
# default prefix=/usr/local 
$ ./install [<prefix>]
```

Replacing lib_dir="..." with sed is a bit stinky though. Perhaps a better solution is to move ./lib/* to ./lib/git-fuzzy/* and update the hard-coded path accordingly. Then we wouldn't need sed, and the current recommended usage would continue to work as well.