### PR TITLE
Make the remote HEAD symbolic ref optional

### DIFF
--- a/lib/load-configs.sh
+++ b/lib/load-configs.sh
@@ -69,7 +69,7 @@ if [ -z "$GF_BASE_REMOTE" ]; then
 fi
 
 if [ -z "$GF_BASE_BRANCH" ]; then
-  GF_BASE_BRANCH="$(git symbolic-ref "refs/remotes/${GF_BASE_REMOTE}/HEAD" | sed "s@^refs/remotes/${GF_BASE_REMOTE}/@@")"
+  GF_BASE_BRANCH="$(git symbolic-ref -q "refs/remotes/${GF_BASE_REMOTE}/HEAD" || echo -n "master" | sed "s@^refs/remotes/${GF_BASE_REMOTE}/@@")"
   export GF_BASE_BRANCH
 fi
 


### PR DESCRIPTION
### What
Make the remote HEAD symbolic ref optional and default the base branch to master when it is not present.

### Why
In some cases the symbolic ref can be lost and the scripts print out errors about that repeatedly. For most operations though it has no impact. Defaulting to master which is the most common default branch of git repos should catch some of the cases where it is needed and the ref was lost. It might be ideal to leave it as an empty string though in those cases.

Related to #13 although I do not think this addresses the core issues people are reporting there.