### PR TITLE
Add BusyBox `bc` compatibility

### DIFF
--- a/lib/core.sh
+++ b/lib/core.sh
@@ -14,7 +14,10 @@ export FZF_DEFAULT_OPTS="\
   --bind 'change:top' \
   --no-height"
 
-export GF_BC_STL=' define min(a, b) { if (a < b) return a else return b } define max(a, b) { if (a > b) return a else return b } '
+export GF_BC_STL='
+define min(a, b) { if (a < b) return a else return b }
+define max(a, b) { if (a > b) return a else return b }
+'
 
 preview_window_settings() {
   IS_VERTICAL="$(run_bc_program "__WIDTH__ / __HEIGHT__ < $GF_VERTICAL_THRESHOLD")"


### PR DESCRIPTION
When using the BusyBox version of `bc`, `git-fuzzy` throws errors such
as:

```
bc: bad statement terminator at 'define max(a, b) { if (a > b) return a else return b }   239 / 58 < 2.0'
bc: bad statement terminator at 'define max(a, b) { if (a > b) return a else return b }   max(50, min(80, 100 - ((7000 + (11 * 239))  / 239)))'
invalid preview window layout: right:%
```

Apparently, the BusyBox version requires a newline between expressions.
The `GF_BC_STL` in the `lib/core.sh` environment variable has been updated
accordingly.