### PR TITLE
Prepend existing fzf defaults to custom bindings

### DIFF
--- a/lib/core.sh
+++ b/lib/core.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export FZF_DEFAULT_OPTS="\
+  $FZF_DEFAULT_OPTS \
   --border \
   --layout=reverse \
   --bind 'ctrl-space:toggle-preview' \


### PR DESCRIPTION
Closes #19.

From manually trying different argument combos on the command line, it seems like duplicate arguments are resolved by using the last one specified, so this seems right.