### PR TITLE
fix typing queries did not displayed.

### DIFF
--- a/lib/modules/helpers/log.sh
+++ b/lib/modules/helpers/log.sh
@@ -15,11 +15,11 @@ gf_helper_log_diff_query() {
 gf_helper_log_menu_content() {
   QUERY="$(git fuzzy helper log_log_query "$1")"
   shift
-  if [ -n "$1" ]; then
+  if [ -n "$QUERY" ]; then
     # shellcheck disable=2086
-    gf_git_command_with_header_hidden_parameters 2 "$GF_LOG_MENU_PARAMS" log "$@" $QUERY
+    gf_git_command_with_header_hidden_parameters 2 "$GF_LOG_MENU_PARAMS" log $@ $QUERY
   else
-    gf_git_command_with_header_hidden_parameters 2 "$GF_LOG_MENU_PARAMS" log "$@"
+    gf_git_command_with_header_hidden_parameters 2 "$GF_LOG_MENU_PARAMS" log $@
   fi
 }
 

--- a/lib/modules/helpers/reflog.sh
+++ b/lib/modules/helpers/reflog.sh
@@ -17,9 +17,9 @@ gf_helper_reflog_menu_content() {
   shift
   if [ -n "$QUERY" ]; then
     # shellcheck disable=2086
-    gf_git_command_with_header_hidden_parameters 2 "$GF_REFLOG_MENU_PARAMS" reflog "$@" $QUERY
+    gf_git_command_with_header_hidden_parameters 2 "$GF_REFLOG_MENU_PARAMS" reflog $@ $QUERY
   else
-    gf_git_command_with_header_hidden_parameters 2 "$GF_REFLOG_MENU_PARAMS" reflog "$@"
+    gf_git_command_with_header_hidden_parameters 2 "$GF_REFLOG_MENU_PARAMS" reflog $@
   fi
 }
 


### PR DESCRIPTION
### Description
using ```git fuzzy log``` without option ```e.g. -G Foo```, typing queries did not displayed. 

### Process
I checked in the following steps.(example)

1. type ```git fuzzy log```
1. type ``` foobar```
1. The expected result is ```git log foobar```, but it will be ```git log ''```.

### Fix
1. typed query is displayed
1. delete single quote

### Screen capture
#### before
![before](https://user-images.githubusercontent.com/6185139/97343190-8a702d80-18ca-11eb-9c85-d995f14a6194.gif)
#### after
![after](https://user-images.githubusercontent.com/6185139/97343207-8f34e180-18ca-11eb-95d2-af8da80ff5e5.gif)
