### PR TITLE
Use `lsd` to preview directories if present

### DIFF
--- a/lib/modules/helpers/status.sh
+++ b/lib/modules/helpers/status.sh
@@ -3,6 +3,8 @@
 GF_STATUS_DIRECTORY_PREVIEW_COMMAND='ls -l --color=always'
 if type exa >/dev/null 2>&1; then
   GF_STATUS_DIRECTORY_PREVIEW_COMMAND='exa -l --color=always'
+elif type lsd >/dev/null 2>&1; then
+  GF_STATUS_DIRECTORY_PREVIEW_COMMAND='lsd -l --color=always'
 fi
 
 GF_STATUS_FILE_PREVIEW_COMMAND='cat'


### PR DESCRIPTION
This PR adds a fallback to [`lsd`](https://github.com/lsd-rs/lsd) as a colorized alternative to `ls` when previewing directories.

The main motivation behind this change is that `lsd` is maintained while `exa` is not.