### PR TITLE
pass /dev/tty to editor command

### DIFF
--- a/lib/modules/helpers/status.sh
+++ b/lib/modules/helpers/status.sh
@@ -64,7 +64,7 @@ gf_helper_status_edit() {
     gf_log_error 'tried to EDIT in status with no file(s)'
   else
     # shellcheck disable=2086
-    gf_interactive_command_logged "$EDITOR" $GF_EDITOR_ARGS "$@"
+    gf_interactive_command_logged "$EDITOR" $GF_EDITOR_ARGS "$@" < /dev/tty
   fi
 }
 


### PR DESCRIPTION
without this, `nano` gives me a strange stdin error.

I'm not entirely sure why this works (there may be a more elegant solution) but it does.
