### PR TITLE
feat: support brew installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # I use this file to keep my private TODO list
 TODO.md
+.idea/

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Search the log and corresponding diff at once. Notice that when you use `|` the 
 
 ## Installing
 
-`fzf` is **required**:
 ```bash
-brew install fzf
+brew tap AppleBoiy/git-fuzzy
+brew install git-fuzzy
 ```
 
 ### Bash


### PR DESCRIPTION
**Add Homebrew Formula for `git-fuzzy`**

This PR introduces a Homebrew formula for the `git-fuzzy` CLI tool, enabling easy installation via Homebrew. 

For convenience, you might consider creating your own Homebrew tap repository using the provided formula. You can view and adapt the formula at this URL: [https://github.com/AppleBoiy/homebrew-git-fuzzy](https://github.com/AppleBoiy/homebrew-git-fuzzy). 
