### PR TITLE
fix: properly parse fzf entries with git status indicator

### DIFF
--- a/lib/modules/helpers/status.sh
+++ b/lib/modules/helpers/status.sh
@@ -38,7 +38,12 @@ gf_helper_status_preview_content() {
 }
 
 gf_helper_status_menu_content() {
-  gf_git_command_with_header 2 status --short
+  # Use a custom command instead of gf_git_command_with_header to avoid color codes
+  # that would break field parsing in the status interpreter
+  printf "%s" "$GRAY" "$BOLD" '$ ' "$CYAN" "$BOLD" "$GIT_CMD status --short" "$NORMAL"
+  echo
+  echo
+  "$GIT_CMD" -c color.status=false status --short
 }
 
 gf_helper_status_add() {


### PR DESCRIPTION
I'm not sure if this actually works yet, but copy/edit/etc don't work when there is a status indicator on the file (`??`, `M`, etc)

<img width="1992" height="1648" alt="CleanShot 2025-11-18 at 15 54 58@2x" src="https://github.com/user-attachments/assets/9eb2d84a-6046-4732-a677-ebf630e35a89" />

Will test and revise, unless I'm doing something wrong to trigger this in the first place.