### PR TITLE
Fix index.lock contention when running modifying commands quickly

### DIFF
--- a/lib/core.sh
+++ b/lib/core.sh
@@ -36,6 +36,9 @@ if [ -z "$GF_FZF_DEFAULTS_SET" ]; then
     --bind \"$(lowercase "$GIT_FUZZY_SELECT_ALL_KEY"):select-all\""
 fi
 
+# Prevent background read-only git operations (like git status in the preview) from
+# taking optional locks and conflicting with explicit operations like git add.
+export GIT_OPTIONAL_LOCKS=0
 
 GF_BC_STL='
 define min(a, b) { if (a < b) return a else return b }


### PR DESCRIPTION
Running modifying commands (like `git add` or `git reset`) quickly in `git-fuzzy` can sometimes result in `index.lock` errors. 

This happens because `fzf` asynchronously runs read-only commands in the background (such as `git status` for the list and `git diff` for the preview pane). While these commands are read-only, Git will opportunistically acquire an optional lock on the index to refresh its cache. If this happens at the exact moment a modifying command is executed, it causes a lock conflict.

This PR sets `export GIT_OPTIONAL_LOCKS=0` in the core configuration. This built-in Git feature instructs background and read-only Git commands to skip taking optional locks, ensuring that modifying commands can execute successfully without contention.