### PR TITLE
feat: migrate from hub to gh

### DIFF
--- a/bin/git-fuzzy
+++ b/bin/git-fuzzy
@@ -41,7 +41,7 @@ git_fuzzy_dir="$script_dir/.."
 . "$git_fuzzy_dir/lib/modules/status.sh"
 . "$git_fuzzy_dir/lib/modules/stash.sh"
 
-. "$git_fuzzy_dir/lib/modules/hub/pr.sh"
+. "$git_fuzzy_dir/lib/modules/gh/pr.sh"
 
 . "$git_fuzzy_dir/lib/modules/helpers.sh"
 # -----------------------------------------
@@ -74,15 +74,13 @@ fi
 
 # NB: checking for actually _unset_
 # shellcheck disable=2016
-if [ -z "${HUB_AVAILABLE+X}" ]; then
-  if type hub >/dev/null 2>&1; then
-    export HUB_AVAILABLE="YES"
-    export GIT_CMD="hub"
-    gf_log_debug '`hub` found, enabling GitHub support.'
+if [ -z "${GH_AVAILABLE+X}" ]; then
+  if type gh >/dev/null 2>&1; then
+    export GH_AVAILABLE="YES"
+    gf_log_debug '`gh` found, enabling GitHub support.'
   else
-    export HUB_AVAILABLE=""
-    export GIT_CMD="git"
-    gf_log_debug '`hub` not found, disabling GitHub support.'
+    export GH_AVAILABLE=""
+    gf_log_debug '`gh` not found, disabling GitHub support.'
   fi
 fi
 

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -177,18 +177,18 @@ gf_command_with_header() {
 }
 
 gf_git_command() {
-  "$GIT_CMD" -c color.ui=always "$@"
+  git -c color.ui=always "$@"
 }
 
 gf_git_command_with_header() {
   NUM="$1"
   shift
-  printf "%s" "$GRAY" "$BOLD" '$ ' "$CYAN" "$BOLD" "$GIT_CMD $(quote_params "$@")" "$NORMAL"
+  printf "%s" "$GRAY" "$BOLD" '$ ' "$CYAN" "$BOLD" "git $(quote_params "$@")" "$NORMAL"
   # shellcheck disable=2034
   for i in $(seq 1 "$NUM"); do
     echo
   done
-  "$GIT_CMD" -c color.ui=always "$@"
+  git -c color.ui=always "$@"
 }
 
 gf_git_command_with_header_default_parameters() {
@@ -198,13 +198,13 @@ gf_git_command_with_header_default_parameters() {
   shift
   SUB_COMMAND="$1"
   shift
-  printf "%s" "$GRAY" "$BOLD" '$ ' "$CYAN" "$BOLD" "$GIT_CMD $SUB_COMMAND $(quote_params "$@")" "$NORMAL"
+  printf "%s" "$GRAY" "$BOLD" '$ ' "$CYAN" "$BOLD" "git $SUB_COMMAND $(quote_params "$@")" "$NORMAL"
   # shellcheck disable=2034
   for i in $(seq 0 "$NUM"); do
     [ "$i" -gt 0 ] && echo
   done
-  gf_log_command_string "$GIT_CMD -c color.ui=always '$SUB_COMMAND' $DEFAULT_SUBCOMMAND_PARAMETERS $(quote_params "$@")"
-  eval "$GIT_CMD -c color.ui=always '$SUB_COMMAND' $DEFAULT_SUBCOMMAND_PARAMETERS $(quote_params "$@")"
+  gf_log_command_string "git -c color.ui=always '$SUB_COMMAND' $DEFAULT_SUBCOMMAND_PARAMETERS $(quote_params "$@")"
+  eval "git -c color.ui=always '$SUB_COMMAND' $DEFAULT_SUBCOMMAND_PARAMETERS $(quote_params "$@")"
 }
 
 gf_quit() {

--- a/lib/load-configs.sh
+++ b/lib/load-configs.sh
@@ -60,8 +60,8 @@ if [ -z "$GF_DIFF_SEARCH_DEFAULTS" ]; then
   export GF_DIFF_SEARCH_DEFAULTS="-G"
 fi
 
-if [ -z "$GF_HUB_PR_FORMAT" ]; then
-  export GF_HUB_PR_FORMAT='%pC%>(8)%I%Creset  %t%  l%n'
+if [ -z "$GF_GH_PR_FORMAT" ]; then
+  export GF_GH_PR_FORMAT='{{range .}}{{tablerow (printf "#%v" .number) .title (timeago .updatedAt)}}{{end}}'
 fi
 
 if [ -z "$GF_LOG_MENU_PARAMS" ]; then

--- a/lib/modules/gh/pr.sh
+++ b/lib/modules/gh/pr.sh
@@ -23,20 +23,20 @@ gf_fzf_pr_select() {
 }
 
 gf_pr() {
-  if [ "$HUB_AVAILABLE" = 'YES' ]; then
+  if [ "$GH_AVAILABLE" = 'YES' ]; then
     gf_command_logged git fetch "$GF_BASE_REMOTE"
     if [ $# -eq 0 ]; then
       git fuzzy helper pr_menu_content | gf_fzf_pr_select
     elif [[ "$1" =~ [0-9]+ ]]; then
-      DIFF_PARAMS="$(hub pr show --format='%sB %sH' "$1")"
-      if [ -z "$DIFF_PARAMS" ]; then
+      DIFF_PARAMS="$(gh pr view "$1" --json baseRefName,headRefName --jq '"\(.baseRefName) \(.headRefName)"')"
+      if [ -n "$DIFF_PARAMS" ]; then
         eval "git fuzzy diff $DIFF_PARAMS"
       fi
     else
       gf_log_error '`git fuzzy pr` only accepts one numeric parameter, the PR number'
     fi
   else
-    gf_log_error '`hub` not available; this command requires `hub` to be installed'
+    gf_log_error '`gh` not available; this command requires `gh` to be installed'
     return 1
   fi
 }

--- a/lib/modules/helpers.sh
+++ b/lib/modules/helpers.sh
@@ -11,4 +11,4 @@
 . "$git_fuzzy_dir/lib/modules/helpers/status.sh"
 . "$git_fuzzy_dir/lib/modules/helpers/stash.sh"
 
-. "$git_fuzzy_dir/lib/modules/helpers/hub/pr.sh"
+. "$git_fuzzy_dir/lib/modules/helpers/gh/pr.sh"

--- a/lib/modules/helpers/gh/pr.sh
+++ b/lib/modules/helpers/gh/pr.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 gf_helper_pr_menu_content() {
-  gf_git_command_with_header 2 pr list --format "$GF_HUB_PR_FORMAT"
+  gf_command_with_header 2 gh pr list --json number,title,labels,state,updatedAt --template "$GF_GH_PR_FORMAT"
 }
 
 gf_helper_pr_preview_content() {
   if [ -n "$1" ]; then
-    DIFF_PARAMS="$(hub pr show --format='%sB %sH' "$1")"
+    DIFF_PARAMS="$(gh pr view "$1" --json baseRefName,headRefName --jq '"\(.baseRefName) \(.headRefName)"')"
     if [ -n "$DIFF_PARAMS" ]; then
       # shellcheck disable=2086
       gf_git_command_with_header 1 diff $DIFF_PARAMS
@@ -16,7 +16,7 @@ gf_helper_pr_preview_content() {
 
 gf_helper_pr_select() {
   if [ -n "$1" ]; then
-    DIFF_PARAMS="$(hub pr show --format='%sB %sH' "$1")"
+    DIFF_PARAMS="$(gh pr view "$1" --json baseRefName,headRefName --jq '"\(.baseRefName) \(.headRefName)"')"
     if [ -n "$DIFF_PARAMS" ]; then
       # shellcheck disable=2086
       gf_git_command_with_header 1 fuzzy diff $DIFF_PARAMS
@@ -26,13 +26,13 @@ gf_helper_pr_select() {
 
 gf_helper_pr_show() {
   if [ -n "$1" ]; then
-    gf_git_command_with_header 1 pr show "$1"
+    gh pr view "$1" --web
   fi
 }
 
 gf_helper_pr_log() {
   if [ -n "$1" ]; then
-    DIFF_PARAMS="$(hub pr show --format='%sB..%sH' "$1")"
+    DIFF_PARAMS="$(gh pr view "$1" --json baseRefName,headRefName --jq '"\(.baseRefName)..\(.headRefName)"')"
     if [ -n "$DIFF_PARAMS" ]; then
       # shellcheck disable=2086
       gf_git_command_with_header 1 fuzzy log $DIFF_PARAMS

--- a/lib/modules/main.sh
+++ b/lib/modules/main.sh
@@ -16,7 +16,7 @@ gf_menu_content() {
   echo
   gf_menu_item 'diff' 'compare up to two branches (remote or local)'
 
-  if [ -n "$HUB_AVAILABLE" ]; then
+  if [ -n "$GH_AVAILABLE" ]; then
     echo
     echo "header ${YELLOW}-- 🚧 ${CYAN}${BOLD}GitHub${NORMAL}${YELLOW} 🚧 --${NORMAL}"
     echo


### PR DESCRIPTION
`hub` is deprecated and unmaintained. This replaces all `hub` usage with `gh`, the official GitHub CLI. AI did 99% of the work, but it seems to work great 🙃 

## What changed

- **PR command**: `hub pr list` / `hub pr show` replaced with `gh pr list --json --template` and `gh pr view --json --jq`
- **Git operations**: `$GIT_CMD` removed entirely — all git commands now use literal `git` (hub added zero value here, it just passed through)
- **Detection**: `HUB_AVAILABLE`/`GIT_CMD` env vars replaced with `GH_AVAILABLE`
- **PR list format**: `GF_HUB_PR_FORMAT` (hub's custom `%`-format) replaced with `GF_GH_PR_FORMAT` (Go template using `gh`'s built-in `tablerow` and `timeago` functions; uses `%v` not `%d` since `gh` decodes JSON numbers as float64)
- **Bug fix**: `git fuzzy pr <number>` was running `git fuzzy diff` when the PR lookup *failed* (`-z` check was inverted); now correctly runs on success (`-n`)

## Breaking changes

- `hub` is no longer used or detected. Users who had `hub` installed get no special behavior.
- `GF_HUB_PR_FORMAT` is no longer respected. Users who customized it will need to set `GF_GH_PR_FORMAT` instead (Go template syntax).
- `GIT_CMD` is no longer exported. Users who relied on it externally will need to remove that dependency.

## Requirements

`gh` must be installed and authenticated for `git fuzzy pr` to work. All other subcommands (`diff`, `log`, `status`, `stash`, `branch`, `reflog`) continue to work without it.