### PR TITLE
feat(status): add keybind for full diff view from status menu, fix reload with recent fzf versions

### DIFF
--- a/lib/modules/helpers/status.sh
+++ b/lib/modules/helpers/status.sh
@@ -37,6 +37,33 @@ gf_helper_status_preview_content() {
   fi
 }
 
+# Full-screen pager view of a file's diff, invoked from the inspect keybind.
+gf_helper_status_diff() {
+  STATUS_CODE="$1"
+  FILE_PATH="$2"
+  RENAMED_FILE_PATH="$3"
+
+  # Trap Ctrl-C so it returns to fzf instead of killing git-fuzzy
+  trap 'exit 0' INT
+  # Instruct less (the default pager) to exit immediately on Ctrl-C
+  export LESS="${LESS:-} -K"
+
+  if [ "??" = "$STATUS_CODE" ]; then
+    # new files/dirs
+    if [ -d "$FILE_PATH" ]; then
+      # shellcheck disable=2086
+      $GF_STATUS_DIRECTORY_PREVIEW_COMMAND "$FILE_PATH" | ${PAGER:-less -R}
+    else
+      # shellcheck disable=2086
+      $GF_STATUS_FILE_PREVIEW_COMMAND "$FILE_PATH" | ${PAGER:-less -R}
+    fi
+  elif [ ! -e "$FILE_PATH" ] && [ -n "$RENAMED_FILE_PATH" ]; then
+    git diff HEAD -M -- "$FILE_PATH" "$RENAMED_FILE_PATH"
+  else
+    git diff HEAD -M -- "$FILE_PATH"
+  fi
+}
+
 gf_helper_status_menu_content() {
   gf_git_command_with_header 2 status --short
 }

--- a/lib/modules/status.sh
+++ b/lib/modules/status.sh
@@ -8,13 +8,14 @@ GIT_FUZZY_STATUS_EDIT_KEY="${GIT_FUZZY_STATUS_EDIT_KEY:-Alt-E}"
 GIT_FUZZY_STATUS_COMMIT_KEY="${GIT_FUZZY_STATUS_COMMIT_KEY:-Alt-C}"
 GIT_FUZZY_STATUS_RESET_KEY="${GIT_FUZZY_STATUS_RESET_KEY:-Alt-R}"
 GIT_FUZZY_STATUS_DISCARD_KEY="${GIT_FUZZY_STATUS_DISCARD_KEY:-Alt-U}"
+GIT_FUZZY_STATUS_DIFF_KEY="${GIT_FUZZY_STATUS_DIFF_KEY:-Alt-I}"
 
 GF_STATUS_HEADER='
 Type to filter. '"${WHITE}Enter${NORMAL} to ${GREEN}ACCEPT${NORMAL}"'
 
   '"${GRAY}-- (${NORMAL}*${GRAY}) editor: ${MAGENTA}${EDITOR} ${NORMAL}${GF_EDITOR_ARGS}${NORMAL}"'
   '""'
- '"${GREEN}amend ✁${NORMAL}  ${WHITE}${GIT_FUZZY_STATUS_AMEND_KEY}${NORMAL}  ${GREEN}stage -p ${BOLD}⇡  ${NORMAL}${WHITE}${GIT_FUZZY_STATUS_ADD_PATCH_KEY}${NORMAL}      * ${GREEN}${BOLD}edit ✎${NORMAL}  ${WHITE}$GIT_FUZZY_STATUS_EDIT_KEY${NORMAL}"'
+ '"${GREEN}amend ✁${NORMAL}  ${WHITE}${GIT_FUZZY_STATUS_AMEND_KEY}${NORMAL}  ${GREEN}stage -p ${BOLD}⇡  ${NORMAL}${WHITE}${GIT_FUZZY_STATUS_ADD_PATCH_KEY}${NORMAL}      * ${GREEN}${BOLD}edit ✎${NORMAL}  ${WHITE}$GIT_FUZZY_STATUS_EDIT_KEY${NORMAL}     ${GREEN}${BOLD}inspect 🔍${NORMAL}  ${WHITE}$GIT_FUZZY_STATUS_DIFF_KEY${NORMAL}"'
    '"${GREEN}all ☑${NORMAL}  ${WHITE}${GIT_FUZZY_SELECT_ALL_KEY}${NORMAL}     ${GREEN}stage ${BOLD}⇡${NORMAL}  ${WHITE}$GIT_FUZZY_STATUS_ADD_KEY${NORMAL}     ${RED}${BOLD}discard ✗${NORMAL}  ${WHITE}$GIT_FUZZY_STATUS_DISCARD_KEY${NORMAL}"'
   '"${GREEN}none ☐${NORMAL}  ${WHITE}${GIT_FUZZY_SELECT_NONE_KEY}${NORMAL}     ${GREEN}reset ${RED}${BOLD}⇣${NORMAL}  ${WHITE}$GIT_FUZZY_STATUS_RESET_KEY${NORMAL}    * ${RED}${BOLD}commit ${NORMAL}${RED}⇧${NORMAL}  ${WHITE}$GIT_FUZZY_STATUS_COMMIT_KEY${NORMAL}"'
 
@@ -25,7 +26,7 @@ if [ "$(particularly_small_screen)" = '1' ]; then
 fi
 
 gf_fzf_status() {
-  RELOAD="reload:git fuzzy helper status_menu_content"
+  RELOAD_SYNC="reload-sync(git fuzzy helper status_menu_content)"
 
   gf_fzf -m --header "$GF_STATUS_HEADER" \
             --header-lines=2 \
@@ -34,10 +35,11 @@ gf_fzf_status() {
             --preview 'git fuzzy helper status_preview_content {1} {2} {4}' \
             --bind 'click-header:reload(git fuzzy helper status_menu_content)' \
             --bind 'backward-eof:reload(git fuzzy helper status_menu_content)' \
-            --bind "$(lowercase "$GIT_FUZZY_STATUS_AMEND_KEY"):execute-silent(git fuzzy helper status_amend {+2..})+down+$RELOAD" \
-            --bind "$(lowercase "$GIT_FUZZY_STATUS_ADD_KEY"):execute-silent(git fuzzy helper status_add {+2..})+down+$RELOAD" \
-            --bind "$(lowercase "$GIT_FUZZY_STATUS_RESET_KEY"):execute-silent(git fuzzy helper status_reset {+2..})+down+$RELOAD" \
-            --bind "$(lowercase "$GIT_FUZZY_STATUS_DISCARD_KEY"):execute-silent(git fuzzy helper status_discard {+2..})+$RELOAD"
+            --bind "$(lowercase "$GIT_FUZZY_STATUS_DIFF_KEY"):execute(git fuzzy helper status_diff {1} {2} {4})" \
+            --bind "$(lowercase "$GIT_FUZZY_STATUS_AMEND_KEY"):execute-silent(git fuzzy helper status_amend {+2..})+$RELOAD_SYNC+down" \
+            --bind "$(lowercase "$GIT_FUZZY_STATUS_ADD_KEY"):execute-silent(git fuzzy helper status_add {+2..})+$RELOAD_SYNC+down" \
+            --bind "$(lowercase "$GIT_FUZZY_STATUS_RESET_KEY"):execute-silent(git fuzzy helper status_reset {+2..})+$RELOAD_SYNC+down" \
+            --bind "$(lowercase "$GIT_FUZZY_STATUS_DISCARD_KEY"):execute-silent(git fuzzy helper status_discard {+2..})+$RELOAD_SYNC"
 }
 
 gf_status_interpreter() {


### PR DESCRIPTION
Adds inspect (Alt-I) key to open a file's diff in pager from status menu.

More important change is the reload functionality is now fixed with recent fzf versions. Was working 0.66 for me and broke on 0.70. Here's the AI research on what changed.

---

**fzf 0.70 changed async reload behavior**

fzf 0.70 introduced significant internal performance improvements (1.3–1.9x faster filtering/rendering). As a side effect, the async `reload:` action now resets cursor position when the new list arrives — it no longer preserves the numeric cursor offset that was set by a preceding `down` action.

The old action chain was:
```
execute-silent(cmd) + down + reload:cmd
```
This relied on `down` running first, then `reload:` arriving asynchronously while fzf preserved the cursor position. In fzf 0.70, the async reload overtakes/resets the position.

**The fix: `reload-sync`**

`reload-sync` (available since fzf 0.36.0) performs a synchronous reload — fzf blocks until the new list is fully loaded before executing subsequent actions. Reordering to:
```
execute-silent(cmd) + reload-sync(cmd) + down
```
means `down` runs against the already-settled, final list. No race condition, no position reset.

`--track` is not a viable alternative here because the status prefix changes on staging (` M` → `M `), so fzf can't match the item identity across the reload.

The synchronous block is imperceptible in practice since `git status -s` completes in sub-millisecond time for typical repos.
